### PR TITLE
fix no module named parallel_test bug

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Billy HE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,7 +1,7 @@
 import argparse
 import torch
 import mmcv
-from mmcv.runner import load_checkpoint, parallel_test
+from mmcv.runner import load_checkpoint
 from mmcv.parallel import scatter, collate, MMDataParallel
 from mmdet.core.evaluation.kitti_eval import get_official_eval_result
 from mmdet.core import results2json, coco_eval
@@ -13,6 +13,7 @@ import torch.utils.data
 import os
 from tools.train_utils import load_params_from_file
 from mmdet.datasets import utils
+
 
 def single_test(model, data_loader, saveto=None, class_names=['Car']):
     template = '{} ' + ' '.join(['{:.4f}' for _ in range(15)]) + '\n'
@@ -26,7 +27,7 @@ def single_test(model, data_loader, saveto=None, class_names=['Car']):
     for i, data in enumerate(data_loader):
         with torch.no_grad():
             results = model(return_loss=False, **data)
-        image_shape = (375,1242)
+        image_shape = (375, 1242)
         for re in results:
             img_idx = re['image_idx']
             if re['bbox'] is not None:
@@ -62,9 +63,10 @@ def single_test(model, data_loader, saveto=None, class_names=['Car']):
                     if saveto is not None:
                         of_path = os.path.join(saveto, '%06d.txt' % img_idx)
                         with open(of_path, 'w+') as f:
-                            for name, bbox, dim, loc, ry, score, alpha in zip(anno['name'], anno["bbox"], \
-                            anno["dimensions"], anno["location"], anno["rotation_y"], anno["score"],anno["alpha"]):
-                                line = template.format(name, 0, 0, alpha, *bbox, *dim[[1,2,0]], *loc, ry, score)
+                            for name, bbox, dim, loc, ry, score, alpha in zip(anno['name'], anno["bbox"],
+                                                                              anno["dimensions"], anno["location"], anno["rotation_y"], anno["score"], anno["alpha"]):
+                                line = template.format(
+                                    name, 0, 0, alpha, *bbox, *dim[[1, 2, 0]], *loc, ry, score)
                                 f.write(line)
 
                     anno = {n: np.stack(v) for n, v in anno.items()}
@@ -148,7 +150,8 @@ def main():
         NotImplementedError
     # kitti evaluation
     gt_annos = kitti.get_label_annos(dataset.label_prefix, dataset.sample_ids)
-    result = get_official_eval_result(gt_annos, outputs, current_classes=class_names)
+    result = get_official_eval_result(
+        gt_annos, outputs, current_classes=class_names)
     print(result)
 
 


### PR DESCRIPTION
when run "tools/test.py", get "no module named parallel_test" error. That's because this module is removed from mmcv, while "tools/test.py" still import it and do not use it. So just remove parallel_test from import line.